### PR TITLE
Bug Fixed

### DIFF
--- a/symantec-messaging-gateway/info.json
+++ b/symantec-messaging-gateway/info.json
@@ -214,7 +214,17 @@
       "description": "Searches for audit logs from Symantec Messaging gateway based on the filter criteria that you have specified. Quick Audit Log Search returns the main event fields.",
       "category": "investigation",
       "annotation": "audit_logs_search",
-      "output_schema": {},
+      "output_schema": [
+        {
+          "Time": "",
+          "From": "",
+          "auditUID": "",
+          "To": "",
+          "Original Subject": "",
+          "Verdict(s)": "",
+          "Action(s)": ""
+        }
+      ],
       "parameters": [
         {
           "title": "Search By",
@@ -232,8 +242,8 @@
           ],
           "name": "mandatoryFilterId",
           "value": "Subject",
-          "tooltip": "Select search by",
-          "description": "Select the filter based on which you want to search the audit logs."
+          "tooltip": "Select the search filter based on which you want to search the audit logs.",
+          "description": "Select the search filter based on which you want to search the audit logs."
         },
         {
           "title": "Search Value",
@@ -242,7 +252,6 @@
           "visible": true,
           "type": "text",
           "name": "mandatoryFilterValue",
-          "value": "",
           "tooltip": "Value to search for based on the search by type. Exp baduser@badomain.com for Search by Sender",
           "description": "Value to search for based on the search by type. Exp baduser@badomain.com for Search by Sender"
         },
@@ -253,9 +262,8 @@
           "visible": true,
           "type": "datetime",
           "name": "start_time",
-          "value": "",
-          "tooltip": "Search start time (Search from:)",
-          "description": "Search start time (Search from:)"
+          "tooltip": "Select the DateTime using which you want to filter the result set to only include only those items that have been created after the specified timestamp.",
+          "description": "Select the DateTime using which you want to filter the result set to only include only those items that have been created after the specified timestamp."
         },
         {
           "title": "End Time",
@@ -264,9 +272,8 @@
           "visible": true,
           "type": "datetime",
           "name": "end_time",
-          "value": "",
-          "tooltip": "Search end time (Search until:)",
-          "description": "Search end time (Search until:)"
+          "tooltip": "Select the DateTime using which you want to filter the result set to only include only those items that have been created before the specified timestamp.",
+          "description": "Select the DateTime using which you want to filter the result set to only include only those items that have been created before the specified timestamp."
         },
         {
           "title": "Limit",
@@ -275,9 +282,9 @@
           "visible": true,
           "type": "integer",
           "name": "entriesPerPage",
-          "value": 15,
-          "tooltip": "Entries to return per page",
-          "description": "Specify number of records to return per page."
+          "value": 10,
+          "tooltip": "Specify the maximum number of results, per page, that this operation should return. By default, this option is set as 10.",
+          "description": "Specify the maximum number of results, per page, that this operation should return. By default, this option is set as 10."
         },
         {
           "title": "Offset",
@@ -287,8 +294,8 @@
           "type": "integer",
           "name": "pageNumber",
           "value": 1,
-          "tooltip": "Page number",
-          "description": "Specify the page number from where to fetch the page."
+          "tooltip": "Index of the first item to be returned by this operation. This parameter is useful for pagination and for getting a subset of items. By default, this is set as 1.",
+          "description": "Index of the first item to be returned by this operation. This parameter is useful for pagination and for getting a subset of items. By default, this is set as 1."
         }
       ],
       "enabled": true
@@ -299,7 +306,35 @@
       "description": "Searches for audit logs from Symantec Messaging gateway based on the filter criteria that you have specified. Advanced audit log search which returns all available fields from events",
       "category": "investigation",
       "annotation": "advanced_audit_logs_search",
-      "output_schema": {},
+      "output_schema": [
+        {
+          "Audit ID": "",
+          "Hosts": "",
+          "Accept From": "",
+          "Accept Time": "",
+          "Source": "",
+          "Message ID": "",
+          "Sender": "",
+          "Recipient": "",
+          "Original Recipients": "",
+          "Intended Recipients": "",
+          "Subject": "",
+          "Filter Policy": "",
+          "Policy Group": "",
+          "Verdict": "",
+          "Details": "",
+          "Viruses": "",
+          "Attachments": "",
+          "Suspect Attachments": "",
+          "Scanner Actions": "",
+          "Quarantine Actions": "",
+          "Day Zero Actions": "",
+          "Content Incident Folder Actions": "",
+          "Deliver To": "",
+          "Deliver Time": "",
+          "Untested Verdicts": ""
+        }
+      ],
       "parameters": [
         {
           "title": "Search By",
@@ -317,8 +352,8 @@
           ],
           "name": "mandatoryFilterId",
           "value": "Subject",
-          "tooltip": "Select search by",
-          "description": "Select search by."
+          "tooltip": "Select the search filter based on which you want to search the audit logs.",
+          "description": "Select the search filter based on which you want to search the audit logs."
         },
         {
           "title": "Search Value",
@@ -338,9 +373,8 @@
           "visible": true,
           "type": "datetime",
           "name": "start_time",
-          "value": "",
-          "tooltip": "Search start time (Search from:)",
-          "description": "Search start time (Search from:)"
+          "tooltip": "Select the DateTime using which you want to filter the result set to only include only those items that have been created after the specified timestamp.",
+          "description": "Select the DateTime using which you want to filter the result set to only include only those items that have been created after the specified timestamp."
         },
         {
           "title": "End Time",
@@ -349,31 +383,8 @@
           "visible": true,
           "type": "datetime",
           "name": "end_time",
-          "value": "",
-          "tooltip": "Search end time (Search until:)",
-          "description": "Search end time (Search until:)"
-        },
-        {
-          "title": "Limit",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "integer",
-          "name": "entriesPerPage",
-          "value": 15,
-          "tooltip": "Entries to return per page",
-          "description": "Specify number of records to return per page."
-        },
-        {
-          "title": "Offset",
-          "required": false,
-          "editable": true,
-          "visible": true,
-          "type": "integer",
-          "name": "pageNumber",
-          "value": 1,
-          "tooltip": "Page number",
-          "description": "Specify the page number from where to fetch the page."
+          "tooltip": "Select the DateTime using which you want to filter the result set to only include only those items that have been created before the specified timestamp.",
+          "description": "Select the DateTime using which you want to filter the result set to only include only those items that have been created before the specified timestamp."
         },
         {
           "title": "Remove None ASCII characters",

--- a/symantec-messaging-gateway/operations.py
+++ b/symantec-messaging-gateway/operations.py
@@ -303,8 +303,14 @@ class SMG:
             search_params = build_search_payload(params)
             token = self._login(config)
             search_params.update({'symantec.brightmail.key.TOKEN': token})
+            if params.get('entriesPerPage'):
+                endpoint = AUDIT_LOGS + '$changeEntriesPerPage.flo'
+                response = self._make_request(endpoint, 'post', data=search_params)
             endpoint = AUDIT_LOGS + '$search.flo'
             resp = self._make_request(endpoint, 'post', data=search_params)
+            if params.get('pageNumber') and params.get('pageNumber') > 1:
+                endpoint = AUDIT_LOGS + '$gotoPage.flo'
+                resp = self._make_request(endpoint, 'post', data=search_params)
             json_response = html_to_json(resp.text)
             logger.debug(json.dumps(json_response, indent=3))
             return html_to_json(resp.text)

--- a/symantec-messaging-gateway/release_notes.md
+++ b/symantec-messaging-gateway/release_notes.md
@@ -1,4 +1,6 @@
 # What's New
-- Added actions and sample playbooks:  
+
+- Added actions and sample playbooks:
     - Quick Audit Log Search
     - Advanced Audit Log Search
+- Added output schema for all the actions.


### PR DESCRIPTION
#### Mantis:

- [0902328](https://mantis.fortinet.com/bug_view_page.php?bug_id=0902328) : Quick Audit Log Search : "Limit" and "Offset" fields are not working.
- [0902331](https://mantis.fortinet.com/bug_view_page.php?bug_id=0902331) : Advanced Audit Log Search : "Limit" and "Offset" fields are not working.

#### Description:

- Updated output schema for "Quick Audit Log Search" and "Advanced Audit Log Search" operation.
- Removed "Limit" and "Offset" parameter from "Advanced Audit Log Search" operation as check from UI also they exporting CSV by Time filter parameter not from the "Limit" and "Offset", i.e they are exporting all audit logs by specified time, no issue of 'Limit' and 'Offset'.

#### UTCs:

- [x] Verified "Quick Audit Log Search" and "Advanced Audit Log Search" operation.


